### PR TITLE
feat: allow for die notation when calculating CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var cr = require('dnd-5e-cr-calculator');
 // Arguments: HP, AC, DpR in dice format, Atk, Save DC
 var value = cr.calculateWithDice(5, 14, '7d6+5', 5, 14)
 
-// value should equal '1'
+// value should equal '1' because '7d6+5' averages to 30
 console.log("Your challenge rating is: " + value);
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,29 @@ var value = cr.calculate(5, 14, 30, 5, 14);
 console.log("Your challenge rating is: " + value);
 ```
 
+Alternatively, you can use the `calculateWithDice()` to enter Damage per Round in the dice string format used in the D&amp;D sourcebooks. When this function is used, the Damage per Round is calculated as an average of the dice formula provided. This is then provided to the `calculate()` function to return the CR value.
+
+```javascript
+// An example of calculateWithDice()
+var cr = require('dnd-5e-cr-calculator');
+
+// Arguments: HP, AC, DpR in dice format, Atk, Save DC
+var value = cr.calculateWithDice(5, 14, '7d6+5', 5, 14)
+
+// value should equal '1'
+console.log("Your challenge rating is: " + value);
+```
+
 ##How to Run
 The D&amp;D 5e CR Calculator is written in Coffeescript, and the `package.json` contains scripts for compiling the Coffeescript and running tests locally. To get the project up and running locally is very simple:
 
 ```
 git clone
 npm install
+npm run compile
 ```
+
+Also, running the tests is as simple as `npm run test` or `npm run test:watch`.
 
 ##Licensing
 The `dnd-5e-cr-calculator` package is released under the MIT license.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnd-5e-cr-calculator",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A calculator for D&D 5e's Challenge Rating statistic.",
   "main": "dist/calculateChallengeRating.js",
   "scripts": {

--- a/src/calculateChallengeRating.coffee
+++ b/src/calculateChallengeRating.coffee
@@ -1,5 +1,7 @@
 _ = require 'lodash'
 
+diceInputErrorMsg = "All dice inputs need to be in the following format: {number}d{number}\+{number}-{number}."
+
 calculate = (hp, ac, dpr, atk, sdc) ->
 
   throw "Zero or lower values are not allowed for Hit Points." if hp <= 0
@@ -51,8 +53,35 @@ calculate = (hp, ac, dpr, atk, sdc) ->
 roundUpDifference = (one, two) ->
   _.ceil((one - two)/2)
 
+calculateWithDice = (hp, ac, diceDpr, atk, sdc) ->
+  avgDpr = getAverageDieValue diceDpr
+  calculate hp, ac, avgDpr, atk, sdc
+
+getAverageDieValue = (diceDpr) ->
+  dprComponents = diceDpr.split(/(\dd\d|\-|\+)/)
+  averageComponents = []
+  componentModifier = 1
+  for component in dprComponents
+    if component.match(/\dd\d/)
+      numberComponent = parseInt(component[0])
+      dieValueComponent = parseInt(component[2])
+      localDprAverage = ((dieValueComponent + 1) * numberComponent)/2
+      averageComponents.push localDprAverage * componentModifier
+    else if component.match(/\+/)
+      componentModifier = 1
+    else if component.match(/\-/)
+      componentModifier = -1
+    else if component.match(/^[0-9]+$/)
+      averageComponents.push parseInt(component) * componentModifier
+    else if component is ''
+      continue
+    else
+      throw diceInputErrorMsg
+  Math.round(_.sum averageComponents)
+
 module.exports = {
   calculate: calculate
+  calculateWithDice: calculateWithDice
 }
 
 # CR Information

--- a/src/calculateChallengeRatingSpec.coffee
+++ b/src/calculateChallengeRatingSpec.coffee
@@ -138,3 +138,85 @@ test 'calculate() defaults to CR 30 when arguments are higher than CR 30', (asse
   assert.equals actual, expected, "Expected offense numbers that exceeded those of CR 30 to result in CR 30."
 
   assert.end()
+
+test 'calculateWithDice() determines the correct DPR with which to calculate CR', (assert) ->
+
+  actual = cr.calculateWithDice 60, 13, '6d6', 4, 12
+  expected = '2'
+
+  assert.equals actual, expected, "Expected the average DPR to be 21, yielding a result of CR 2."
+
+  actual = cr.calculateWithDice 45, 13, '1d6+2', 3, 13
+  expected = '1/2'
+
+  assert.equals actual, expected, "Expected the average DPR to be 6, yielding a result of CR 1/2."
+
+  actual = cr.calculateWithDice 45, 13, '1d4-2', 3, 13
+  expected = '1/8'
+
+  assert.equals actual, expected, "Expected the average DPR to be 1, yielding a result of CR 1/8"
+
+  actual = cr.calculateWithDice 170, 15, '6d6+8d6', 6, 15
+  expected = '7'
+
+  assert.equals actual, expected, "Expected the average DPR to be 49, yielding a result of CR 7"
+
+  actual = cr.calculateWithDice 170, 15, '6d6+8d6+10', 6, 15
+  expected = '8'
+
+  assert.equals actual, expected, "Expected the average DPR to be 59, yielding a result of CR 8"
+
+  actual = cr.calculateWithDice 30, 13, '3d4-6', 3, 13
+  expected = '1/8'
+
+  assert.equals actual, expected, "Expected the average DPR to be 2, yielding a result of CR 1/8"
+
+  actual = cr.calculateWithDice 120, 14, '3d4+10+6d6-10', 5, 14
+  expected = '4'
+
+  assert.equals actual, expected, "Expected the average DPR to be 29, yielding a result of CR 4"
+
+  assert.end()
+
+test 'calculateWithDice() throws the correct errors when provided invalid formats', (assert) ->
+
+  # Array OoB error
+  actual = ->
+    cr.calculateWithDice 60, 13, 'd6', 4, 12
+  expected = /All dice inputs need to be in the following format: {number}d{number}\+{number}-{number}\./
+
+  assert.throws actual, expected, "Expected an informative error message when dice in the format 'd{number}'."
+
+  actual = ->
+    cr.calculateWithDice 60, 13, '6d', 4, 12
+
+  assert.throws actual, expected, "Expected an informative error message when dice in the format '{number}d'."
+
+  # Number Parsing error
+  actual = ->
+    cr.calculateWithDice 60, 13, 'td6', 4, 12
+
+  assert.throws actual, expected, "Expected an informative error message when dice in the format '{letter}d{number}'"
+
+  actual = ->
+    cr.calculateWithDice 60, 13, '6dt', 4, 12
+
+  assert.throws actual, expected, "Expected an informative error message when dice in the format '{number}d{letter}'"
+
+  actual = ->
+    cr.calculateWithDice 50, 15, 'breakbreakbreak', 5, 17
+
+  assert.throws actual, expected, "Expected an informative error message when bad data is passed in."
+
+  actual = ->
+    cr.calculateWithDice 60, 13, '-6d6', 4, 12
+  expected = /Negative values are not allowed for Damage per Round\./
+
+  assert.throws actual, expected, "Expected a negative die value to result in a negative value error"
+
+  actual = ->
+    cr.calculateWithDice 60, 13, '4d4-6d6', 4, 12
+
+  assert.throws actual, expected, "Expected a negative die value to result in a negative value error"
+
+  assert.end()


### PR DESCRIPTION
Add the calculateWithDice function with getAverageDieValue function
Perform averages on basic dice value formats
Allow for static modifiers on the dice values
Add basic error handling for bad dice formats
Handle multiple die sets for calculating DPR, as well as static modifiers
Update documentation for 2.0
